### PR TITLE
An improved way of preserving and replaying original mappings

### DIFF
--- a/fnl/nvlime/keymaps/globals.fnl
+++ b/fnl/nvlime/keymaps/globals.fnl
@@ -44,17 +44,17 @@
                     "Close all nvlime windows except main ones")
   (km.buffer.normal gm.normal.close_floating_window
                     #(when (not (window.close_last_float))
-                       (km.feedkeys "<Esc>"))
+                       ($1))
                     "Close last opened floating window")
   (km.buffer.normal gm.normal.scroll_up
                     #(when (not (window.scroll_float
                                   opts.floating_window.scroll_step true))
-                       (km.feedkeys gm.normal.scroll_up))
+                       ($1))
                     "Scroll up last opened floating window")
   (km.buffer.normal gm.normal.scroll_down
                     #(when (not (window.scroll_float
                                   opts.floating_window.scroll_step))
-                       (km.feedkeys gm.normal.scroll_down))
+                       ($1))
                     "Scroll down last opened floating window")
   (when add-split?
     (split-focus "vertical leftabove split" gm.normal.split_left)

--- a/fnl/nvlime/utilities.fnl
+++ b/fnl/nvlime/utilities.fnl
@@ -71,6 +71,14 @@
     (nvim_win_set_cursor
       winid [linenr col-0])))
 
+;;; fn [any] -> any|nil
+(fn find-if [pred list]
+  (var result nil)
+  (each [_ item (ipairs list) &until result]
+    (when (pred item)
+      (set result item)))
+  result)
+
 {: text->lines
  : echo
  : echo-warning
@@ -79,4 +87,5 @@
  : calc-lines-size
  : get-win-cursor
  : set-win-cursor
- : in-coord-range?}
+ : in-coord-range?
+ : find-if}

--- a/lua/nvlime/keymaps/globals.lua
+++ b/lua/nvlime/keymaps/globals.lua
@@ -21,7 +21,8 @@ for _, keys in ipairs({gm.normal.slit_left, gm.normal.split_right, gm.normal.spl
   else
     local tbl_17_auto = split_keys
     for _0, key in ipairs(keys) do
-      table.insert(tbl_17_auto, key)
+      local val_18_auto = key
+      table.insert(tbl_17_auto, val_18_auto)
     end
   end
 end
@@ -51,25 +52,25 @@ globals.add = function(add_close_3f, add_split_3f)
     return window.close_all_except_main()
   end
   km.buffer.normal(gm.normal.close_nvlime_windows, _8_, "Close all nvlime windows except main ones")
-  local function _9_()
+  local function _9_(_241)
     if not window.close_last_float() then
-      return km.feedkeys("<Esc>")
+      return _241()
     else
       return nil
     end
   end
   km.buffer.normal(gm.normal.close_floating_window, _9_, "Close last opened floating window")
-  local function _11_()
+  local function _11_(_241)
     if not window.scroll_float(opts.floating_window.scroll_step, true) then
-      return km.feedkeys(gm.normal.scroll_up)
+      return _241()
     else
       return nil
     end
   end
   km.buffer.normal(gm.normal.scroll_up, _11_, "Scroll up last opened floating window")
-  local function _13_()
+  local function _13_(_241)
     if not window.scroll_float(opts.floating_window.scroll_step) then
-      return km.feedkeys(gm.normal.scroll_down)
+      return _241()
     else
       return nil
     end

--- a/lua/nvlime/utilities.lua
+++ b/lua/nvlime/utilities.lua
@@ -78,4 +78,15 @@ local function set_win_cursor(winid, pos)
   local col_0 = (psl.second(pos) - 1)
   return nvim_win_set_cursor(winid, {linenr, col_0})
 end
-return {["text->lines"] = text__3elines, echo = echo, ["echo-warning"] = echo_warning, ["echo-error"] = echo_error, ["plist->table"] = plist__3etable, ["calc-lines-size"] = calc_lines_size, ["get-win-cursor"] = get_win_cursor, ["set-win-cursor"] = set_win_cursor, ["in-coord-range?"] = in_coord_range_3f}
+local function find_if(pred, list)
+  local result = nil
+  for _, item in ipairs(list) do
+    if result then break end
+    if pred(item) then
+      result = item
+    else
+    end
+  end
+  return result
+end
+return {["text->lines"] = text__3elines, echo = echo, ["echo-warning"] = echo_warning, ["echo-error"] = echo_error, ["plist->table"] = plist__3etable, ["calc-lines-size"] = calc_lines_size, ["get-win-cursor"] = get_win_cursor, ["set-win-cursor"] = set_win_cursor, ["in-coord-range?"] = in_coord_range_3f, ["find-if"] = find_if}


### PR DESCRIPTION
Certain mappings, such as scrolling in floating windows, try to be non-intrusive, and when they can't be applied they use nvim_feedkeys() to replay the original mapping.
However, this simple approach does not always work. For example, I have <C-n> remapped to gt which stops working and instead scrolls by a single line even when there are no floating windows.

This change brings a more sophisticated mechanism of capturing and replaying the original mapping. The implementation was inspired by anuvyklack/keymap-amend.nvim