### PR TITLE
Fix REPL window opening in a redundant split

### DIFF
--- a/fnl/nvlime/utilities.fnl
+++ b/fnl/nvlime/utilities.fnl
@@ -71,6 +71,14 @@
     (nvim_win_set_cursor
       winid [linenr col-0])))
 
+;;; fn [any] -> any|nil
+(fn find-if [pred list]
+  (var result nil)
+  (each [_ item (ipairs list) &until result]
+    (when (pred item)
+      (set result item)))
+  result)
+
 {: text->lines
  : echo
  : echo-warning
@@ -79,4 +87,5 @@
  : calc-lines-size
  : get-win-cursor
  : set-win-cursor
- : in-coord-range?}
+ : in-coord-range?
+ : find-if}

--- a/lua/nvlime/utilities.lua
+++ b/lua/nvlime/utilities.lua
@@ -78,4 +78,15 @@ local function set_win_cursor(winid, pos)
   local col_0 = (psl.second(pos) - 1)
   return nvim_win_set_cursor(winid, {linenr, col_0})
 end
-return {["text->lines"] = text__3elines, echo = echo, ["echo-warning"] = echo_warning, ["echo-error"] = echo_error, ["plist->table"] = plist__3etable, ["calc-lines-size"] = calc_lines_size, ["get-win-cursor"] = get_win_cursor, ["set-win-cursor"] = set_win_cursor, ["in-coord-range?"] = in_coord_range_3f}
+local function find_if(pred, list)
+  local result = nil
+  for _, item in ipairs(list) do
+    if result then break end
+    if pred(item) then
+      result = item
+    else
+    end
+  end
+  return result
+end
+return {["text->lines"] = text__3elines, echo = echo, ["echo-warning"] = echo_warning, ["echo-error"] = echo_error, ["plist->table"] = plist__3etable, ["calc-lines-size"] = calc_lines_size, ["get-win-cursor"] = get_win_cursor, ["set-win-cursor"] = set_win_cursor, ["in-coord-range?"] = in_coord_range_3f, ["find-if"] = find_if}


### PR DESCRIPTION
If there are multiple tabs where each has its own REPL window (sharing the same buffer), then an issue occurs that opens a new split with a REPL window instead of reusing an existing one. This occurs because there is always only one "main window" which has a single associated REPL window, and there is no code that recalculates the current REPL window when the main one changes (e.g, when switching tabs).

Steps to reproduce:
1. Start a server and connect to it.
2. Send something to the REPL so that its window opens in a split in the current tab.
3. Open a new tab and repeat step 2 there.
4. Go back to the first tab, repeat step 2.

This change adds specific behaviour for REPL windows to try and reuse existing ones in the current tab.