### PR TITLE
Workaround for `E1510` being thrown by Neovim

### DIFF
--- a/autoload/nvlime/async.vim
+++ b/autoload/nvlime/async.vim
@@ -99,6 +99,8 @@ function! s:ChanInputCB(job_id, data, source) dict
       call add(obj_list, json_obj)
       let buffered = ''
     catch /^Vim\%((\a\+)\)\=:E474/  " Invalid argument
+    catch /^Vim\%((\a\+)\)\=:E1510/  " Same as above
+      " See https://github.com/monkoose/nvlime/issues/12
     endtry
   endfor
 


### PR DESCRIPTION
There is a bug in Neovim that makes it throw `E1510` instead of `E474` if the parsed JSON string is very large and incomplete.  This patch works around the issue by also catching `E1510` and handling it the same way as `E474`.  This patch can safely be reverted once the issue is fixed in Neovim.

See also https://github.com/neovim/neovim/issues/29886